### PR TITLE
fix: script not finding participant name

### DIFF
--- a/src/lib/google-meet.js
+++ b/src/lib/google-meet.js
@@ -50,7 +50,7 @@ export function getParticipantsList() {
 
 function getParticipantNameForVideo(video) {
   // First check if this video is displayed in the main grid.
-  const ancestor = video.parentElement.parentElement;
+  const ancestor = video.parentElement.parentElement.parentElement;
   let name = ancestor.querySelector('[data-self-name]');
   if (!name) {
     // If not, check if this video is the self video at the top-right corner.


### PR DESCRIPTION
this was probably caused because google meet added an extra div between video and participant name

closes #25 